### PR TITLE
Color demo with ember collection and virtual each

### DIFF
--- a/addon/components/impagination-collection.js
+++ b/addon/components/impagination-collection.js
@@ -5,7 +5,7 @@ import Dataset from 'ember-impagination/dataset';
 export default Ember.Component.extend({
   layout: layout,
   'initial-read-offset': 0,
-  'load-horizon': 1,
+  'load-horizon': 2,
   'unload-horizon': Infinity,
   'page-size': null,
   'fetch': null,
@@ -28,6 +28,7 @@ export default Ember.Component.extend({
           Ember.run.debounce(this, 'flushQueue', offset, 1, false);
         }
       });
+      Object.defineProperty(collection, "length", { get: collection.length });
       return collection;
     } else {
       return [];
@@ -104,7 +105,14 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
     return record || undefined;
   },
 
-  length: Ember.computed(function () {
+  slice(start, end) {
+    if(start < 0) { return []; }
+    let records = this.datasetState.records.slice(start, end);
+    this.objectReadAt(start);
+    return records || undefined;
+  },
+
+  length: function() {
     var lastPage = {
       records: []
     };
@@ -115,5 +123,5 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
       totalRecords = (datasetState.pages.length - 1) * datasetState.pageSize + lastPage.records.length;
     }
     return totalRecords;
-  })
+  }
 });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-try": "0.0.6"
+    "ember-new-computed": "1.0.3",
+    "ember-try": "0.0.6",
+    "virtual-each": "jasonmit/virtual-each"
   },
   "keywords": [
     "ember-addon"

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  emberCollection: true,
+
   fetch: function (pageOffset, pageSize, stats) {
     let spectrum = new RGBSpectrum(300).colors;
     let delay = 200; //ms

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -187,3 +187,13 @@ body {
   background-color: black;
   opacity: .4;
 }
+
+.virtual-each {
+  overflow-y: auto;
+}
+
+.infinite-list-content {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/tests/dummy/app/templates/components/impagination-list.hbs
+++ b/tests/dummy/app/templates/components/impagination-list.hbs
@@ -1,0 +1,1 @@
+{{yield records state pages positionIndex}}

--- a/tests/dummy/app/templates/components/impagination-list.hbs
+++ b/tests/dummy/app/templates/components/impagination-list.hbs
@@ -1,1 +1,0 @@
-{{yield records state pages positionIndex}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -14,9 +14,19 @@
     <div class="demo_read-offset">Current Read Offset: {{datasetState.readOffset}} </div>
     <div class="demo_records-wrapper">
       <div class="demo_records-list-container" style="height: 500px; width: 600px;">
-        {{#ember-collection items=records estimated-height=500px  estimated-width=600px cell-layout=(fixed-grid-layout 600 70) as |record index|}}
-          <div class="demo_record" style={{color-block record.content.hsl}}>Record {{index}}</div>
-        {{/ember-collection}}
+	{{#if emberCollection }}
+	  {{#ember-collection items=records estimated-height=500px  estimated-width=600px cell-layout=(fixed-grid-layout 600 70) as |record index|}}
+            <div class="demo_record" style={{color-block record.content.hsl}}>Record {{index}}</div>
+          {{/ember-collection}}
+	{{else}}
+	  {{#virtual-each
+             height=500
+             itemHeight=70
+             items=records as |record index virtualIndex|
+          }}
+	    <div class="demo_record" style={{color-block record.content.hsl}}>Record {{index}}</div>
+	  {{/virtual-each}}
+	{{/if}}
       </div>
     </div>
   {{/impagination-collection}}


### PR DESCRIPTION
This PR introduces the `virtual-each` (React-style-each) into `ember-impagination`. Therefore, the `impagination-collection` component interface has all functionality for `ember-collection` and `virtual-each`.

The `length` getter was tricky and for some unknown reason has to be explicitly defined outside the `create` of the `collection` Object