### PR TITLE
Exercise collection interface

### DIFF
--- a/addon/components/impagination-collection.js
+++ b/addon/components/impagination-collection.js
@@ -19,12 +19,6 @@ export default Ember.Component.extend({
     });
   }),
 
-  pages: Ember.computed('datasetState', function() {
-    return PagesInterface.create({
-      datasetState: this.get('datasetState')
-    });
-  }),
-
   dataset: Ember.computed('page-size', 'load-horizon', 'unload-horizon', 'fetch', function() {
     return new Dataset({
       pageSize: this.get('page-size'),
@@ -52,7 +46,7 @@ export default Ember.Component.extend({
     this._super.apply(this, arguments);
 
     this.setInitialState();
-    this.get('dataset').setReadOffset(this.get('initialReadOffset') || 0);
+    this.get('dataset').setReadOffset(this.get('initial-read-offset') || 0);
   }
 });
 

--- a/addon/components/impagination-collection.js
+++ b/addon/components/impagination-collection.js
@@ -4,7 +4,6 @@ import Dataset from 'impagination/dataset';
 
 export default Ember.Component.extend({
   layout: layout,
-  'initial-read-offset': 0,
   'load-horizon': 2,
   'unload-horizon': Infinity,
   'page-size': null,
@@ -42,11 +41,11 @@ export default Ember.Component.extend({
     if (!this.isDestroyed) { this.set(key, value); }
   },
 
-  didInitAttrs() {
+  didReceiveAttrs() {
     this._super.apply(this, arguments);
 
     this.setInitialState();
-    this.get('dataset').setReadOffset(this.get('initial-read-offset') || 0);
+    this.get('dataset').setReadOffset(this.get('read-offset') || 0);
   }
 });
 
@@ -97,7 +96,6 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
     if (length < 0) {
       return [];
     }
-
     Ember.run.schedule('afterRender', this, 'objectReadAt', start);
     return Array.from(new Array(length), (_, i)=> {
       return this.datasetState.get(start + i);

--- a/addon/components/impagination-collection.js
+++ b/addon/components/impagination-collection.js
@@ -33,7 +33,7 @@ export default Ember.Component.extend({
       fetch: this.get('fetch'),
       observe: (datasetState)=> {
         Ember.run(() => {
-          this.set('datasetState', datasetState);
+          this.safeSet('datasetState', datasetState);
         });
       }
     });
@@ -43,6 +43,10 @@ export default Ember.Component.extend({
   setInitialState: Ember.observer('dataset', function() {
     this.set('datasetState', this.get('dataset.state'));
   }),
+
+  safeSet: function(key, value) {
+    if (!this.isDestroyed) { this.set(key, value); }
+  },
 
   didInitAttrs() {
     this._super.apply(this, arguments);
@@ -75,7 +79,7 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
 
   objectAt(i) {
     let record = this.datasetState.get(i);
-    Ember.run.debounce(this, 'objectReadAt', i, 1, false);
+    Ember.run.debounce(this, 'objectReadAt', i, 1, true);
     return record;
   },
 

--- a/addon/components/impagination-collection.js
+++ b/addon/components/impagination-collection.js
@@ -71,6 +71,8 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
     });
   }),
 
+  readOffset: Ember.computed.readOnly('datasetState.readOffset'),
+
   objectAt(i) {
     let record = this.datasetState.get(i);
     Ember.run.debounce(this, 'objectReadAt', i, 1, true);

--- a/addon/templates/components/impagination-collection.hbs
+++ b/addon/templates/components/impagination-collection.hbs
@@ -1,1 +1,1 @@
-{{yield records datasetState pages}}
+{{yield records}}

--- a/tests/dummy/app/components/record-player.js
+++ b/tests/dummy/app/components/record-player.js
@@ -8,16 +8,16 @@ export default Ember.Component.extend({
   'pages': null,
   'datasetState': null,
   elementWidth: null,
-  totalRecords: Ember.computed.readOnly('datasetState.length'),
-  pageWidth: Ember.computed('incrementWidth', 'datasetState.pageSize', function(){
-    return this.get('incrementWidth') * this.get('datasetState.pageSize');
+  totalRecords: Ember.computed.readOnly('records.length'),
+  pageWidth: Ember.computed('incrementWidth', 'pages.firstObject', function(){
+    return this.get('incrementWidth') * this.get('pages.firstObject.size');
   }),
   incrementWidth: Ember.computed('elementWidth', 'totalRecords', function(){
     return this.get('elementWidth') / this.get('totalRecords');
   }),
-  readHeadOffset: Ember.computed('datasetState.readOffset', 'incrementWidth', 'pageWidth', function(){
+  readHeadOffset: Ember.computed('records.readOffset', 'incrementWidth', 'pageWidth', function(){
     let incrementWidth = this.get('incrementWidth');
-    return this.get('datasetState.readOffset') * incrementWidth;
+    return this.get('records.readOffset') * incrementWidth;
   }),
   pageStyle: Ember.computed('pageWidth', function() {
     return Ember.String.htmlSafe("width:"+this.get('pageWidth')+"px;");
@@ -25,18 +25,18 @@ export default Ember.Component.extend({
   readHeadStyle: Ember.computed('readHeadOffset', function(){
     return Ember.String.htmlSafe("left:"+this.get('readHeadOffset')+"px;");
   }),
-  loadHorizonStyle: Ember.computed('datasetState.loadHorizon', 'pageWidth', 'readHeadOffset', function(){
-    let left = this.get('readHeadOffset') - (this.get('datasetState.loadHorizon')*this.get('pageWidth')) / this.get('datasetState.pageSize');
-    let width = 2*this.get('datasetState.loadHorizon')*this.get('pageWidth') / this.get('datasetState.pageSize');
+  loadHorizonStyle: Ember.computed('loadHorizon', 'pageWidth', 'readHeadOffset', 'pages.firstObject', function(){
+    let left = this.get('readHeadOffset') - (this.get('loadHorizon')*this.get('pageWidth')) / this.get('pages.firstObject.size');
+    let width = 2*this.get('loadHorizon')*this.get('pageWidth') / this.get('pages.firstObject.size');
 
     return Ember.String.htmlSafe("left:"+left+"px; width:"+width+"px;");
   }),
-  unloadHorizonLeftStyle: Ember.computed('elementWidth', 'datasetState.unloadHorizon', 'pageWidth', 'readHeadOffset', function(){
-    let right = this.get('elementWidth') - this.get('readHeadOffset') + (this.get('datasetState.unloadHorizon')*this.get('pageWidth'));
+  unloadHorizonLeftStyle: Ember.computed('elementWidth', 'unloadHorizon', 'pageWidth', 'readHeadOffset', function(){
+    let right = this.get('elementWidth') - this.get('readHeadOffset') + (this.get('unloadHorizon')*this.get('pageWidth'));
     return Ember.String.htmlSafe("right:"+right+"px;");
   }),
-  unloadHorizonRightStyle: Ember.computed('datasetState.unloadHorizon', 'pageWidth', 'readHeadOffset', function(){
-    let left = this.get('readHeadOffset') + (this.get('datasetState.unloadHorizon')*this.get('pageWidth'));
+  unloadHorizonRightStyle: Ember.computed('unloadHorizon', 'pageWidth', 'readHeadOffset', function(){
+    let left = this.get('readHeadOffset') + (this.get('unloadHorizon')*this.get('pageWidth'));
     return Ember.String.htmlSafe("left:"+left+"px;");
   }),
   _adjustWidth(){

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -9,7 +9,7 @@
   {{input value=pageSize type=number id="ps"}}
 </div>
 <div class="demo_dataset-wrapper">
-  {{#impagination-collection fetch=fetch initial-read-offset=initialReadOffset load-horizon=loadHorizon unload-horizon=unloadHorizon page-size=pageSize as |records readOffset|}}
+  {{#impagination-collection fetch=fetch read-offset=initialReadOffset load-horizon=loadHorizon unload-horizon=unloadHorizon page-size=pageSize as |records|}}
     {{record-player  pages=records.pages records=records loadHorizon=loadHorizon unloadHorizon=unloadHorizon}}
     <div class="demo_read-offset">Current Read Offset: {{datasetState.readOffset}} </div>
     <div class="demo_records-wrapper">

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -9,8 +9,8 @@
   {{input value=pageSize type=number id="ps"}}
 </div>
 <div class="demo_dataset-wrapper">
-  {{#impagination-collection fetch=fetch initial-read-offset=initialReadOffset load-horizon=loadHorizon unload-horizon=unloadHorizon page-size=pageSize as |records datasetState pages|}}
-    {{record-player  pages=records.pages datasetState=datasetState records=records}}
+  {{#impagination-collection fetch=fetch initial-read-offset=initialReadOffset load-horizon=loadHorizon unload-horizon=unloadHorizon page-size=pageSize as |records readOffset|}}
+    {{record-player  pages=records.pages records=records loadHorizon=loadHorizon unloadHorizon=unloadHorizon}}
     <div class="demo_read-offset">Current Read Offset: {{datasetState.readOffset}} </div>
     <div class="demo_records-wrapper">
       <div class="demo_records-list-container" style="height: 500px; width: 600px;">

--- a/tests/integration/components/impagination-collection-test.js
+++ b/tests/integration/components/impagination-collection-test.js
@@ -46,7 +46,7 @@ describeComponent(
       expect(this.server.requests.length).to.equal(3);
     });
 
-    describe("reading records from the begining with {{each}}", function() {
+    describe("exercising the CollectionInterface with {{each}}", function() {
       beforeEach(function() {
         this.render(hbs`
         {{#impagination-collection
@@ -56,15 +56,22 @@ describeComponent(
           load-horizon=30
           unload-horizon=50
           as |records|}}
+          <div class="records">Total Records: {{records.length}}</div>
           {{#each records as |record|}}
-            <p class="record">{{record.content.name}}</p>
+            <div class="record">{{record.content.name}}</div>
           {{/each}}
         {{/impagination-collection}}
         `);
       });
+
+      it("requests pages from the server", function() {
+        expect(this.server.requests.length).to.equal(3);
+      });
+
       it("renders a set of empty records up to the loadHorizon", function() {
-        expect(this.$('p.record').length).to.equal(30);
-        expect(this.$('p.record').first().text()).to.equal('');
+        expect(this.$('.records').first().text()).to.equal('Total Records: 30');
+        expect(this.$('.record').length).to.equal(30);
+        expect(this.$('.record').first().text()).to.equal('');
       });
 
       describe("resolving fetches", function() {
@@ -73,33 +80,18 @@ describeComponent(
         });
 
         it("renders a set of resolved records up to the loadHorizon", function() {
-          expect(this.$('p').length).to.equal(30);
-          expect(this.$('p').first().text()).to.equal('Record 0');
+          expect(this.$('.record').length).to.equal(30);
+          expect(this.$('.record').first().text()).to.equal('Record 0');
         });
       });
-    });
-    describe("reading records from the middle with {{each}}", function() {
-      beforeEach(function() {
-        this.render(hbs`
-        {{#impagination-collection
-          fetch=fetch
-          initial-read-offset=30
-          page-size=10
-          load-horizon=30
-          unload-horizon=50
-          as |records|}}
-          <p class="records">{{records.length}}</p>
-        {{/impagination-collection}}
-        `);
-      });
-
-      describe("resolving fetches", function() {
+      describe("rejecting fetches", function() {
         beforeEach(function() {
-          this.server.resolveAll();
+          this.server.rejectAll();
         });
 
-        it("renders a set of resolved records up to the loadHorizon", function() {
-          expect(this.$('p').first().text()).to.equal('60');
+        it("renders empty rejected records up to the loadHorizon", function() {
+          expect(this.$('.record').length).to.equal(30);
+          expect(this.$('.record').first().text()).to.equal('');
         });
       });
     });

--- a/tests/integration/components/impagination-collection-test.js
+++ b/tests/integration/components/impagination-collection-test.js
@@ -5,6 +5,7 @@ import {
   it
 } from 'ember-mocha';
 import {
+  describe,
   beforeEach
 } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
@@ -32,6 +33,58 @@ describeComponent(
         page-size=10
       }}`);
       expect(this.$()).to.have.length(1);
+      expect(this.server.requests.length).to.equal(1);
+    });
+
+    it('renders with loadHorizon', function() {
+      this.render(hbs`
+      {{impagination-collection
+        fetch=fetch
+        page-size=5
+        load-horizon=15
+      }}`);
+      expect(this.server.requests.length).to.equal(3);
+    });
+
+    describe("reading records", function() {
+      beforeEach(function() {
+        var observe = (state) => {
+          this.datasetState = state;
+        };
+        this.set('observe', observe);
+        this.render(hbs`
+        {{#impagination-collection
+          fetch=fetch
+          observe=observe
+          page-size=10
+          load-horizon=30
+          unload-horizon=50
+          as |records|}}
+          <div class="impagination-collection">
+            {{#each records as |record|}}
+              <p>{{record.content.name}}</p>
+            {{/each}}
+          </div>
+        {{/impagination-collection}}
+        `);
+      });
+      it("renders a set of empty records up to the loadHorizon", function() {
+        expect(this.$('p').length).to.equal(30);
+        expect(this.$('p').first().text()).to.equal('');
+      });
+
+      describe("resolving fetches", function() {
+        beforeEach(function() {
+          this.server.resolveAll();
+        });
+
+        it("renders a set of resolved records up to the loadHorizon", function() {
+          expect(this.$('p').length).to.equal(30);
+          expect(this.$('p').first().text()).to.equal('Record 0');
+        });
+
+      });
+
     });
   }
 );

--- a/tests/integration/components/impagination-collection-test.js
+++ b/tests/integration/components/impagination-collection-test.js
@@ -48,10 +48,11 @@ describeComponent(
 
     describe("exercising the CollectionInterface with {{each}}", function() {
       beforeEach(function() {
+        this.set('readOffset', 0);
         this.render(hbs`
         {{#impagination-collection
           fetch=fetch
-          initial-read-offset=0
+          read-offset=readOffset
           page-size=10
           load-horizon=30
           unload-horizon=50
@@ -84,6 +85,7 @@ describeComponent(
           expect(this.$('.record').first().text()).to.equal('Record 0');
         });
       });
+
       describe("rejecting fetches", function() {
         beforeEach(function() {
           this.server.rejectAll();
@@ -94,6 +96,17 @@ describeComponent(
           expect(this.$('.record').first().text()).to.equal('');
         });
       });
+
+      describe("incrementing the readOffset", function() {
+        beforeEach(function() {
+          this.set('readOffset', 10);
+        });
+
+        it("requests another page from the server", function() {
+          expect(this.server.requests.length).to.equal(4);
+        });
+      });
+
     });
   }
 );

--- a/tests/integration/components/impagination-collection-test.js
+++ b/tests/integration/components/impagination-collection-test.js
@@ -46,31 +46,25 @@ describeComponent(
       expect(this.server.requests.length).to.equal(3);
     });
 
-    describe("reading records", function() {
+    describe("reading records from the begining with {{each}}", function() {
       beforeEach(function() {
-        var observe = (state) => {
-          this.datasetState = state;
-        };
-        this.set('observe', observe);
         this.render(hbs`
         {{#impagination-collection
           fetch=fetch
-          observe=observe
+          initial-read-offset=0
           page-size=10
           load-horizon=30
           unload-horizon=50
           as |records|}}
-          <div class="impagination-collection">
-            {{#each records as |record|}}
-              <p>{{record.content.name}}</p>
-            {{/each}}
-          </div>
+          {{#each records as |record|}}
+            <p class="record">{{record.content.name}}</p>
+          {{/each}}
         {{/impagination-collection}}
         `);
       });
       it("renders a set of empty records up to the loadHorizon", function() {
-        expect(this.$('p').length).to.equal(30);
-        expect(this.$('p').first().text()).to.equal('');
+        expect(this.$('p.record').length).to.equal(30);
+        expect(this.$('p.record').first().text()).to.equal('');
       });
 
       describe("resolving fetches", function() {
@@ -82,9 +76,32 @@ describeComponent(
           expect(this.$('p').length).to.equal(30);
           expect(this.$('p').first().text()).to.equal('Record 0');
         });
-
+      });
+    });
+    describe("reading records from the middle with {{each}}", function() {
+      beforeEach(function() {
+        this.render(hbs`
+        {{#impagination-collection
+          fetch=fetch
+          initial-read-offset=30
+          page-size=10
+          load-horizon=30
+          unload-horizon=50
+          as |records|}}
+          <p class="records">{{records.length}}</p>
+        {{/impagination-collection}}
+        `);
       });
 
+      describe("resolving fetches", function() {
+        beforeEach(function() {
+          this.server.resolveAll();
+        });
+
+        it("renders a set of resolved records up to the loadHorizon", function() {
+          expect(this.$('p').first().text()).to.equal('60');
+        });
+      });
     });
   }
 );

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -29,3 +29,59 @@ if (!Array.prototype.fill) {
     return O;
   };
 }
+
+// Production steps of ECMA-262, Edition 6, 22.1.2.1
+// Reference: https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.from
+if (!Array.from) {
+  Array.from = (function () {
+    var toStr = Object.prototype.toString;
+    var isCallable = function (fn) {
+      return typeof fn === 'function' || toStr.call(fn) === '[object Function]';
+    };
+    var toInteger = function (value) {
+      var number = Number(value);
+      if (isNaN(number)) { return 0; }
+      if (number === 0 || !isFinite(number)) { return number; }
+      return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+    };
+    var maxSafeInteger = Math.pow(2, 53) - 1;
+    var toLength = function (value) {
+      var len = toInteger(value);
+      return Math.min(Math.max(len, 0), maxSafeInteger);
+    };
+
+    // The length property of the from method is 1.
+    return function from(arrayLike/*, mapFn, thisArg */) {
+      var C = this;
+      var items = Object(arrayLike);
+      if (arrayLike == null) {
+        throw new TypeError("Array.from requires an array-like object - not null or undefined");
+      }
+      var mapFn = arguments.length > 1 ? arguments[1] : void undefined;
+      var T;
+      if (typeof mapFn !== 'undefined') {
+        if (!isCallable(mapFn)) {
+          throw new TypeError('Array.from: when provided, the second argument must be a function');
+        }
+        if (arguments.length > 2) {
+          T = arguments[2];
+        }
+      }
+      var len = toLength(items.length);
+      var A = isCallable(C) ? Object(new C(len)) : new Array(len);
+      var k = 0;
+      var kValue;
+      while (k < len) {
+        kValue = items[k];
+        if (mapFn) {
+          A[k] = typeof T === 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
+        } else {
+          A[k] = kValue;
+        }
+        k += 1;
+      }
+      A.length = len;
+      return A;
+    };
+  }());
+}

--- a/tests/test-server.js
+++ b/tests/test-server.js
@@ -60,6 +60,11 @@ export class Server {
     this.requests.forEach((request) => request.resolve());
     return Ember.RSVP.Promise.all(this.requests);
   }
+
+  rejectAll() {
+    this.requests.forEach((request) => request.reject());
+    return Ember.RSVP.Promise.all(this.requests);
+  }
 }
 
 /**


### PR DESCRIPTION
#### yield only records in template
- Cease yielding datasetState and pages since `pages` exists on records via `records.pages`

#### Setting debounce immediate to true
A couple of reasons for this:
1. When overwriting the `slice` method, we always `setReadOffset` at the `start`
of the slice.
2. The integration for rendering records uses an {{#each records as
|record|}} helpers, which uses `objectAt` just like
ember-collection. However, with the debounce at false, we sometimes
`setReadOffset` to the end of the array `records.length`, which then forces the
collection to request more records and grow. This occurs infinitely.