### PR TITLE
[WIP] Reset dataset programatically

### DIFF
--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -51,13 +51,19 @@ export default Ember.Component.extend({
 
   actions: {
     reset: function() {
-      this.get('dataset').setReadOffset(0);
+      this.get('dataset').setReadOffset();
     },
     refresh: function() {
-      this.get('dataset').setReadOffset(this.get('dataset.state.readOffset') || 0);
+      let readOffset = this.get('dataset.state.readOffset');
+      this.get('dataset').setReadOffset();
+      this.get('dataset').setReadOffset(readOffset);
     },
     setReadOffset: function(offset) {
-      this.get('dataset').setReadOffset(offset || 0);
+      let readOffset = this.get('dataset.state.readOffset');
+      if(offset === readOffset) {
+        this.get('dataset').setReadOffset();
+      }
+      this.get('dataset').setReadOffset(offset);
     }
   }
 });

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -50,10 +50,10 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    reset: () => {
+    reset: function() {
       this.get('dataset').setReadOffset(0);
     },
-    refresh: () => {
+    refresh: function() {
       this.get('dataset').setReadOffset(this.get('dataset.state.readOffset') || 0);
     },
     setReadOffset: function(offset) {

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
     });
   }),
 
-  dataset: Ember.computed('page-size', 'load-horizon', 'unload-horizon', 'fetch', function() {
+  dataset: Ember.computed('page-size', 'load-horizon', 'unload-horizon', 'fetch', 'on-observe', function() {
     return new Dataset({
       pageSize: this.get('page-size'),
       loadHorizon: this.get('load-horizon'),
@@ -27,6 +27,7 @@ export default Ember.Component.extend({
       observe: (datasetState)=> {
         Ember.run(() => {
           this.safeSet('datasetState', datasetState);
+          this.sendAction('on-observe', this.get('records'));
         });
       }
     });
@@ -100,5 +101,17 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
     return Array.from(new Array(length), (_, i)=> {
       return this.datasetState.get(start + i);
     });
+  },
+
+  reset() {
+    this.get('dataset').setReadOffset(0);
+  },
+
+  refresh() {
+    this.get('dataset').setReadOffset(this.get('readOffset') || 0);
+  },
+
+  setReadOffset(offset) {
+    this.get('dataset').setReadOffset(offset || 0);
   }
 });

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
       observe: (datasetState)=> {
         Ember.run(() => {
           this.safeSet('datasetState', datasetState);
-          this.sendAction('on-observe', this.get('records'));
+          this.sendAction('on-observe', this.get('records'), this._actions);
         });
       }
     });
@@ -47,6 +47,18 @@ export default Ember.Component.extend({
 
     this.setInitialState();
     this.get('dataset').setReadOffset(this.get('read-offset') || 0);
+  },
+
+  actions: {
+    reset: () => {
+      this.get('dataset').setReadOffset(0);
+    },
+    refresh: () => {
+      this.get('dataset').setReadOffset(this.get('dataset.state.readOffset') || 0);
+    },
+    setReadOffset: function(offset) {
+      this.get('dataset').setReadOffset(offset || 0);
+    }
   }
 });
 
@@ -101,17 +113,5 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
     return Array.from(new Array(length), (_, i)=> {
       return this.datasetState.get(start + i);
     });
-  },
-
-  reset() {
-    this.get('dataset').setReadOffset(0);
-  },
-
-  refresh() {
-    this.get('dataset').setReadOffset(this.get('readOffset') || 0);
-  },
-
-  setReadOffset(offset) {
-    this.get('dataset').setReadOffset(offset || 0);
   }
 });

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "ember-mocha": "~0.8.0",
     "pretender": "~0.10.1",


### PR DESCRIPTION
This introduces an API feature which allows the user to reset, refresh or setReadOffset on the dataset both from the handlebars template, as well as from a controller / route. 
Fixes #34

> Note: This PR only provides an API to set the readOffset on the dataset explicitly. In order to reset all fetched records in the dataset, I refer you to https://github.com/thefrontside/ember-impagination/issues/34#issuecomment-169219312. 
> TLDR: If you want to fully reset the `impagination-dataset` to an empty state, you have to pass it a new `fetch` function.

Reasons for resetting or refreshing a dataset:
1. Since the dataset only resets when `{{impagination-dataset}}` parameters change, there is no clear way to reset the dataset. When we want to fetch data from the backend with a query which does not rerender the route, we must manually fire a dataset reset/refresh.
2. To comply with a planned feature to filter-records on the frontend, we will want to manually refresh the dataset to apply filters on records which may have changed. Since filtering data on the frontend does not rerender the route, we must manually fire a reset/refresh.

New API features:

``` javascript
actions: {
  reset: function()    // sets the dataset to readOffset `0`
  refresh: function() // sets the dataset to the currentReadOffset
  setReadOffset: function(offset) // sets the dataset to passed-in `offset`
}
```
### Refreshing Dataset Examples

In this example we refresh the dataset upon updated search queries through the `{{search-pane}}` component.
#### from child components

``` hbs
{{#impagination-dataset fetch=myFetch as |dataset|}}
  {{#search-pane search=(action "performSearch") on-search-results=(action "reset" target=dataset)}}
      {{#ember-collection items=dataset as |record|}}
        {{chat-search-result result=record}}
      {{/ember-collection}}
  {{/search-pane}}
{{/impagination-dataset}}
```
#### from parent route

We use the `on-observe` action, which fires whenever there exists a new dataset to observe. We can then perform actions on the new dataset, which are PASSED-UP TO THE ROUTE, along with the dataset.

``` hbs
{{#impagination-dataset fetch=myFetch on-observe=(action "observeDataset") as |dataset|}}
  {{#search-pane search=(action "performSearch")}}
      {{#ember-collection items=dataset as |record|}}
        {{chat-search-result result=record}}
      {{/ember-collection}}
  {{/search-pane}}
{{/impagination-dataset}}
```

``` javascript
    observeDataset: function(dataset, actions) { // dataset and actions are passed-up
        this.set('dataset', dataset);
        this.set('actions', actions);
    },
   _refreshDataset() {
        let refresh = this.get('actions.refresh');
        refresh.call(this.get('dataset'))
    }
```

TODO / WIP:
- [x] refresh should fire the observer
- [x] setReadOffset must fire observer when we pass-in the current `readOffset` of the dataset
- [ ] Write tests for firing actions from child components
