### PR TITLE
Update README for passing fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,53 @@ Record 2
 ...
 Record 9
 ```
+
+#### Passing the Fetch Function
+In **Ember 1.13 and above**, we can use closure-actions to pass the fetch function into `ember-impagination`
+```handlebars
+{{#impagination-dataset fetch=(action "fetch")}}
+```
+
+```javascript
+// app/route/record.js
+export default Ember.Route.extend({
+
+  // fetch() function is invoked whenever a page is requested within the loadHorizon
+  actions: {
+    fetch(pageOffset, pageSize, stats) { // function which returns a "thenable" (*required*)
+    let params = {
+      query: query,
+    };
+    // fetch a page of records at the pageOffset
+    return this.store.query('record', params).then((data) => {
+      let meta = data.get('meta');
+      stats.totalPages = meta.totalPages;
+      return data.toArray();
+    });
+  }
+});
+```
+
+> We do not recommend deifning `fetch` inside your controller because it requires [injecting the store into the controller](https://github.com/thefrontside/ember-impagination/issues/39#issuecomment-172101680)
+
+In **Ember 1.12 and below** we cannot define `fetch` in our actions hash. We must instead bind it to our controller.
+```handlebars
+{{#impagination-dataset fetch=fetch)}}
+```
+
+```javascript
+// app/route/record.js
+export default Ember.Route.extend({
+    fetch: function(pageOffset, pageSize, stats) {
+        return this.store.query(...);
+    }),
+    setupController: function(controller, model){
+        this._super.apply(this, arguments);
+        controller.set('fetch', this.fetch.bind(this));
+    })
+});
+```
+
 ### Create your own Dataset
 If `{{impagination-dataset}}` is not an ideal component for your unique `Impagination` needs, you can get into the nitty gritty, and use `Impagination` directly. If you find yourself creating your own `Dataset`, let us know how you are using `Dataset` and `Impagination`. It may be a reason for improvements or another ember addon.
 


### PR DESCRIPTION
Documents #39 

There are many options for passing fetch that have left developers confused. We attempt here to answer those questions.

Defining `fetch`
 - In the actions hash or separately
 - In the route, or in the controller
 - What does it look like in Ember 1.13 (Closure-Actions)
 - What does it look like in Ember 1.12


Ember 1.13 and above allows
```handlebars
{{impagination-dataset fetch=fetch}}
{{impagination-dataset fetch=(action fetch)}}
```

Ember 1.12 and below allows
```handlebars
{{impagination-dataset fetch=fetch}}
```

We explicitly indicate that we can never pass a string . . . 
THE FOLLOWING ARE NOT ALLOWED
```handlebars
{{impagination-dataset fetch="fetch"}}
{{impagination-dataset fetch=(action "fetch")}}
```

