### PR TITLE
Filtering records

### DIFF
--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -69,8 +69,8 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
     if(!!this.filter) {
       this._records = records.filter(
         (record, index, records) => {
-          let item = record.content;
-          let items = records.map((record) => {return record.content;});
+          let item = record && record.content;
+          let items = records.map((record) => {return record && record.content;});
           return this.filter(item, index, items);
         }
       );

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -96,9 +96,11 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
   },
 
   objectReadAt(record) {
-    let page = record.page;
-    let offset = page.offset * page.size + record.index;
-    this.get('dataset').setReadOffset(offset);
+    if(record) {
+      let page = record.page;
+      let offset = page.offset * page.size + record.index;
+      this.get('dataset').setReadOffset(offset);
+    }
   },
 
   slice(start, end) {

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -52,20 +52,14 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    reset: function() {
-      this.get('dataset').setReadOffset();
+    reset: () => {
+      this.get('dataset').setReadOffset(0);
     },
-    refresh: function() {
-      let readOffset = this.get('dataset.state.readOffset');
-      this.get('dataset').setReadOffset();
-      this.get('dataset').setReadOffset(readOffset);
+    refresh: () => {
+      this.get('dataset').setReadOffset(this.get('dataset.state.readOffset') || 0);
     },
     setReadOffset: function(offset) {
-      let readOffset = this.get('dataset.state.readOffset');
-      if(offset === readOffset) {
-        this.get('dataset').setReadOffset();
-      }
-      this.get('dataset').setReadOffset(offset);
+      this.get('dataset').setReadOffset(offset || 0);
     }
   }
 });

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -69,7 +69,9 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
     if(!!this.filter) {
       this._records = records.filter(
         (record, index, records) => {
-          return this.filter(record, index, records);
+          let item = record.content;
+          let items = records.map((record) => {return record.content;});
+          return this.filter(item, index, items);
         }
       );
     } else {

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -52,10 +52,10 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    reset: () => {
+    reset: function() {
       this.get('dataset').setReadOffset(0);
     },
-    refresh: () => {
+    refresh: function() {
       this.get('dataset').setReadOffset(this.get('dataset.state.readOffset') || 0);
     },
     setReadOffset: function(offset) {

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -53,16 +53,21 @@ export default Ember.Component.extend({
 
   actions: {
     reset: function() {
-      this.set('datasetState', this.get('dataset.state'));
-      this.get('dataset').setReadOffset(0);
+      this.get('dataset').setReadOffset();
     },
     refresh: function() {
-      this.set('datasetState', this.get('dataset.state'));
-      this.get('dataset').setReadOffset(this.get('dataset.state.readOffset') || 0);
+      let currentReadOffset = this.get('dataset.state.readOffset');
+      this.get('dataset').setReadOffset();
+      this.get('dataset').setReadOffset(currentReadOffset);
     },
     setReadOffset: function(offset) {
-      this.set('datasetState', this.get('dataset.state'));
-      this.get('dataset').setReadOffset(offset || 0);
+      let currentReadOffset = this.get('dataset.state.readOffset');
+      if(offset !== currentReadOffset) {
+        this.get('dataset').setReadOffset(offset);
+      } else {
+        this.get('dataset').setReadOffset();
+        this.get('dataset').setReadOffset(offset);
+      }
     }
   }
 });

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -15,8 +15,7 @@ export default Ember.Component.extend({
   records: Ember.computed('datasetState', function() {
     return CollectionInterface.create({
       datasetState: this.get('dataset.state'),
-      dataset: this.get('dataset'),
-      filter: this.get('filter')
+      dataset: this.get('dataset')
     });
   }),
 
@@ -29,6 +28,7 @@ export default Ember.Component.extend({
       observe: (datasetState)=> {
         Ember.run(() => {
           this.safeSet('datasetState', datasetState);
+          this.get('records')._applyFilter(this.get('filter'));
           this.sendAction('on-observe', this.get('records'), this._actions);
         });
       }
@@ -53,12 +53,15 @@ export default Ember.Component.extend({
 
   actions: {
     reset: function() {
+      this.set('datasetState', this.get('dataset.state'));
       this.get('dataset').setReadOffset(0);
     },
     refresh: function() {
+      this.set('datasetState', this.get('dataset.state'));
       this.get('dataset').setReadOffset(this.get('dataset.state.readOffset') || 0);
     },
     setReadOffset: function(offset) {
+      this.set('datasetState', this.get('dataset.state'));
       this.get('dataset').setReadOffset(offset || 0);
     }
   }
@@ -74,22 +77,10 @@ var PagesInterface = Ember.Object.extend(Ember.Array, {
 var CollectionInterface = Ember.Object.extend(Ember.Array, {
   init() {
     this._super.apply(this, arguments);
-
-    var records = Array.from(new Array(this.datasetState.length), (_, i)=> {
+    // TODO: this can be sped up by using `pages`
+    this._records = Array.from(new Array(this.datasetState.length), (_, i)=> {
       return this.datasetState.get(i);
     });
-
-    if(!!this.filter) {
-      this._records = records.filter(
-        (record, index, records) => {
-          let item = record && record.content;
-          let items = records.map((record) => {return record && record.content;});
-          return this.filter(item, index, items);
-        }
-      );
-    } else {
-      this._records = records;
-    }
     this.length = this._records.length;
   },
 
@@ -134,5 +125,18 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
     let record = this._records[start];
     Ember.run.schedule('afterRender', this, 'setReadHead', record);
     return this._records.slice(start, end);
+  },
+
+  _applyFilter(filterFn) {
+    if(!!filterFn) {
+      this._records = this._records.filter(
+        (record, index, records) => {
+          let item = record && record.content;
+          let items = records.map((record) => {return record && record.content;});
+          return filterFn(item, index, items);
+        }
+      );
+      this.length = this._records.length;
+    }
   }
 });

--- a/tests/integration/components/impagination-dataset-test.js
+++ b/tests/integration/components/impagination-dataset-test.js
@@ -269,5 +269,57 @@ describeComponent(
         });
       });
     });
+    describe("observing the dataset", function() {
+      beforeEach(function() {
+        this.observedDatasetCounter = 0;
+        var observeDataset = (dataset, actions) => {
+          this.dataset = dataset;
+          this.actions = actions;
+          this.observedDatasetCounter++;
+        };
+
+        this.set('observeDataset', observeDataset);
+        this.render(hbs`
+        {{#impagination-dataset
+          fetch=fetch
+          page-size=10
+          on-observe=observeDataset
+          as |records|}}
+          <div class="records">Total Records: {{records.length}}</div>
+        {{/impagination-dataset}}
+        `);
+      });
+
+      it("fires the on-observe action", function() {
+        expect(this.observedDatasetCounter).to.equal(1);
+        expect(this.dataset.get('readOffset')).to.equal(0);
+      });
+
+      describe("resolving fetches", function() {
+        beforeEach(function() {
+          this.server.resolveAll();
+        });
+
+        it("fires the on-observe action again", function() {
+          expect(this.server.requests.length).to.equal(1);
+          expect(this.observedDatasetCounter).to.equal(2);
+        });
+      });
+
+      describe("firing a setReadOffset Action", function() {
+        beforeEach(function() {
+          let setReadOffset = this.actions.setReadOffset;
+          setReadOffset.call(this.dataset, 10);
+        });
+
+        it("sets the new read offset on the observed dataset", function() {
+          expect(this.dataset.get('readOffset')).to.equal(10);
+        });
+
+        it("requests an additional page from the server", function() {
+          expect(this.server.requests.length).to.equal(2);
+        });
+      });
+    });
   }
 );

--- a/tests/integration/components/impagination-dataset-test.js
+++ b/tests/integration/components/impagination-dataset-test.js
@@ -173,5 +173,47 @@ describeComponent(
         });
       });
     });
+    describe("filtering records", function() {
+      beforeEach(function() {
+        var evenRecords = (record)=> {
+          return record.index % 2 === 0;
+        };
+        this.set('filter', evenRecords);
+        this.set('readOffset', 0);
+        this.render(hbs`
+        {{#impagination-dataset
+          fetch=fetch
+          filter=filter
+          read-offset=readOffset
+          page-size=10
+          load-horizon=30
+          unload-horizon=50
+          as |filteredRecords|}}
+          <div class="filtered_records">Total Filtered Records: {{filteredRecords.length}}</div>
+          {{#each filteredRecords as |record|}}
+            <div class="record">{{record.content.name}}</div>
+          {{/each}}
+        {{/impagination-dataset}}
+        `);
+      });
+
+      it("requests pages from the server", function() {
+        expect(this.server.requests.length).to.equal(3);
+      });
+
+      it("renders a set of empty records up to the loadHorizon", function() {
+        expect(this.$('.filtered_records').first().text()).to.equal('Total Filtered Records: 15');
+      });
+
+      describe("resolving fetches", function() {
+        beforeEach(function() {
+          this.server.resolveAll();
+        });
+
+        it("renders a set of resolved records up to the loadHorizon", function() {
+          expect(this.$('.record').length).to.equal(15);
+        });
+      });
+    });
   }
 );

--- a/tests/integration/components/impagination-dataset-test.js
+++ b/tests/integration/components/impagination-dataset-test.js
@@ -176,7 +176,10 @@ describeComponent(
     describe("filtering records", function() {
       beforeEach(function() {
         var evenRecords = (record)=> {
-          return record.index % 2 === 0;
+          if(record) {
+            return record.id % 2 === 0;
+          }
+          return false;
         };
         this.set('filter', evenRecords);
         this.set('readOffset', 0);
@@ -202,7 +205,7 @@ describeComponent(
       });
 
       it("renders a set of empty records up to the loadHorizon", function() {
-        expect(this.$('.filtered_records').first().text()).to.equal('Total Filtered Records: 15');
+        expect(this.$('.filtered_records').first().text()).to.equal('Total Filtered Records: 0');
       });
 
       describe("resolving fetches", function() {

--- a/tests/test-server.js
+++ b/tests/test-server.js
@@ -91,7 +91,10 @@ export class PageRequest {
 
   resolve() {
     let records = Array.from(new Array(this.size), (_, i)=> {
-      return {name: `Record ${this.offset * this.size + i}`};
+      return {
+        id: i,
+        name: `Record ${this.offset * this.size + i}`
+      };
     });
     this._resolve(records);
     return this;


### PR DESCRIPTION
Filtering records is not only fun, it's necessary. Since we are not dealign with ember-data models, and instead relying on `ember-impagination` to do our fetching and containing the data models, we need a way to introduce filtering.

Just like `fetch`, the `filter` function is passed directly to `ember-impagination` over attributes. The filter function is meant to handle ONLY an individual impagination record. The semantics regarding what to pass into the filter function is up for debate. Currently, we pass-in a `Record` from the `impagination` library.