### PR TITLE
remove use of Array.from

### DIFF
--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -97,8 +97,13 @@ var CollectionInterface = Ember.Object.extend(Ember.Array, {
       return [];
     }
     Ember.run.schedule('afterRender', this, 'objectReadAt', start);
-    return Array.from(new Array(length), (_, i)=> {
-      return this.datasetState.get(start + i);
-    });
+
+    let sliced = [];
+
+    for (let i = 0; i < length; i++) {
+      sliced.push(this.datasetState.get(start + i));
+    }
+
+    return sliced;
   }
 });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "broccoli-babel-transpiler": "^5.4.5",
     "broccoli-funnel": "^0.2.12",
     "broccoli-merge-trees": "^0.2.4",
-    "impagination": "^0.1.3"
+    "impagination": "^0.2.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Instead of relying on Array.from, we use a `for` loop instead.

We also bumped impagination.