### PR TITLE
Small readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,36 @@
 [![Ember Observer Score](http://emberobserver.com/badges/ember-impagination.svg)](http://emberobserver.com/addons/ember-impagination)
 [![Build Status](https://travis-ci.org/thefrontside/ember-impagination.svg)](https://travis-ci.org/thefrontside/ember-impagination)
 
-*Ember-Impagination* is an Ember binding for [Impagination](https://github.com/flexyford/impagination), a front-end data-layer for the paginated API on your server. *Ember-Impagination* leverages the power of Glimmer and provides your component the data it needs to render quickly each and every time.
+*Ember-Impagination* is an Ember binding for
+[Impagination](https://github.com/flexyford/impagination), a front-end
+data-layer for the paginated API on your server. *Ember-Impagination*
+leverages the power of Glimmer and provides your component the data it
+needs to render quickly each and every time.
+
 > Impagination README:
 
-> Whatever your use-case: infinite scrolling lists, a carousel browser, or even a classic page-by-page result list, Impagination frees you to focus on what you want to do with your data, not the micro-logistics of when to fetch it. All you provide Impagination is the logic to fetch a single page, plus how many pages you want it to pre-fetch ahead of you, and it will figure out the rest.
+> Whatever your use-case: infinite scrolling lists, a carousel
+> browser, or even a classic page-by-page result list, Impagination
+> frees you to focus on what you want to do with your data, not the
+> micro-logistics of when to fetch it. All you provide Impagination is
+> the logic to fetch a single page, plus how many pages you want it to
+> pre-fetch ahead of you, and it will figure out the rest.
 
-> Impagination is built using an event-driven immutable style, so it is ideal for use with UI frameworks like Ember . . .
+> Impagination is built using an event-driven immutable style, so it
+> is ideal for use with UI frameworks like Ember . . .
 
 Hence, we present *Ember-Impagination*.
 
-*Ember-Impagination* provides you with a component, `{{impagination-dataset as |data|}}`, you can use to feed data into your templates while having that data look exactly like an `Ember.Array`.
+*Ember-Impagination* provides you with a component,
+`{{impagination-dataset as |data|}}`, you can use to feed data into
+your templates while having that data look exactly like an
+`Ember.Array`.
 
-> Note: *Ember-Impagination* does not provide any of the visual elements in a system like infinite scroll. You'll still need to use a special component like `virtual-each` or `ember-collection`. Instead, *Ember-Impagination* simplifies feeding your components fetched data.
+> Note: *Ember-Impagination* does not provide any of the visual
+> elements in a system like infinite scroll. You'll still need to use
+> a special component like `virtual-each` or
+> `ember-collection`. Instead, *Ember-Impagination* simplifies feeding
+> your components fetched data.
 
 ## Installation
 * `ember install ember-impagination`
@@ -22,17 +40,34 @@ Hence, we present *Ember-Impagination*.
 ## Demo
 [Ember-Impagination Demo](http://thefrontside.github.io/ember-impagination)
 
-The demo presents a finite scroll implementation of *Ember-Impagination*. It scrolls through the ROYGBIV color spectrum by loading and unloading pages of records, where each record is a unique color-hue. At the top of the demo, you will find a visualization for pages. Resolved (Loaded) Pages are green, Pending (Loading) pages are white, and Unrequested (Unloaded) pages are black. The white-bar represents the top-most index of the scroll view.
+The demo presents a finite scroll implementation of
+*Ember-Impagination*. It scrolls through the ROYGBIV color spectrum by
+loading and unloading pages of records, where each record is a unique
+color-hue. At the top of the demo, you will find a visualization for
+pages. Resolved (Loaded) Pages are green, Pending (Loading) pages are
+white, and Unrequested (Unloaded) pages are black. The white-bar
+represents the top-most index of the scroll view.
 
 ![](http://g.recordit.co/iltQTaYwSb.gif)
 
-The demo is implemented using [virtual-each](https://github.com/jasonmit/virtual-each) due to the simplicity of the component. However, *Ember-Impagination* can also be utilized with other components like [ember-collection](https://github.com/emberjs/ember-collection), or even a simple `{{each}}`. By design, *Ember-Impagination* leverages Glimmer and yields paginated data from your server's API to components which expect an array.
+The demo is implemented using
+[virtual-each](https://github.com/jasonmit/virtual-each) due to the
+simplicity of the component. However, *Ember-Impagination* can also be
+utilized with other components like
+[ember-collection](https://github.com/emberjs/ember-collection), or
+even a simple `{{each}}`. By design, *Ember-Impagination* leverages
+Glimmer and yields paginated data from your server's API to components
+which expect an array.
 
 ## Usage
 
 ### Impagination-Dataset Component
 
-To create an `impagination-dataset` there are two *required* parameters, `fetch` and `page-size`. Optional parameters include `load-horizon`, `unload-horizon`, `read-offset`, `unfetch`. See [Impagination](https://github.com/flexyford/impagination) for detailed attribute descriptions.
+To create an `impagination-dataset` there are two *required*
+parameters, `fetch` and `page-size`. Optional parameters include
+`load-horizon`, `unload-horizon`, `read-offset`, `unfetch`. See
+[Impagination](https://github.com/flexyford/impagination) for detailed
+attribute descriptions.
 
 ```hbs
 {{!-- app/templates/index.hbs --}}
@@ -48,9 +83,14 @@ To create an `impagination-dataset` there are two *required* parameters, `fetch`
 {{/impagination-dataset}}
 ```
 
-> In most cases, using a simple `{{each}}` would defeat the purpose of using a data layer like *Ember-Impagination*, and for truly infinite datasets might result in truly infinite loops :scream:
+> In most cases, using a simple `{{each}}` would defeat the purpose of
+> using a data layer like *Ember-Impagination*, and for truly infinite
+> datasets might result in truly infinite loops :scream:
 
-Now, in your route, you can define the actual `(un)fetch` functions that tell `{{impagination-dataset}}` how it should request each individual page, and the `(un)loadHorizon` which specify how many pages to request ahead/behind.
+Now, in your route, you can define the actual `(un)fetch` functions
+that tell `{{impagination-dataset}}` how it should request each
+individual page, and the `(un)loadHorizon` which specify how many
+pages to request ahead/behind.
 
 ```javascript
 // app/route/record.js
@@ -77,11 +117,12 @@ export default Ember.Route.extend({
     this.store.findByIds('record', records.map(r => r.id).then(function(records) {
       records.forEach(record => record.deleteRecord());
     });
-  });
+  }
 })
 ```
 
-This setup will immediatly call fetch twice (for records 0-4 [page 0] and records 5-9 [page 1])
+This setup will immediatly call fetch twice (for records 0-4 [page 0]
+and records 5-9 [page 1])
 ```
 Total Records: 10
 Record 0
@@ -92,7 +133,9 @@ Record 9
 ```
 
 #### Passing the Fetch Function
-In **Ember 1.13 and above**, we can use closure-actions to pass the fetch function into `ember-impagination`
+In **Ember 1.13 and above**, we can use closure-actions to pass the
+fetch function into `ember-impagination`
+
 ```handlebars
 {{#impagination-dataset fetch=(action "fetch")}}
 ```
@@ -118,9 +161,12 @@ export default Ember.Route.extend({
 });
 ```
 
-> We do not recommend deifning `fetch` inside your controller because it requires [injecting the store into the controller](https://github.com/thefrontside/ember-impagination/issues/39#issuecomment-172101680)
+> We do not recommend deifning `fetch` inside your controller because
+> it requires
+> [injecting the store into the controller](https://github.com/thefrontside/ember-impagination/issues/39#issuecomment-172101680)
 
-In **Ember 1.12 and below** we cannot define `fetch` in our actions hash. We must instead bind it to our controller.
+In **Ember 1.12 and below** we cannot define `fetch` in our actions
+hash. We must instead bind it to our controller.
 ```handlebars
 {{#impagination-dataset fetch=fetch)}}
 ```
@@ -129,17 +175,22 @@ In **Ember 1.12 and below** we cannot define `fetch` in our actions hash. We mus
 // app/route/record.js
 export default Ember.Route.extend({
     fetch: function(pageOffset, pageSize, stats) {
-        return this.store.query(...);
-    }),
+      return this.store.query(...);
+    },
     setupController: function(controller, model){
-        this._super.apply(this, arguments);
-        controller.set('fetch', this.fetch.bind(this));
-    })
+      this._super.apply(this, arguments);
+      controller.set('fetch', this.fetch.bind(this));
+    }
 });
 ```
 
 ### Filtering Records
-We fetch records using an immutable style, but we often require filtering by mutable records in our dataset. To enable filtering, pass a filter `callback` to `ember-impagination` as you would to `Array.prototype.filter()`. The filters are applied as soon as a page is resolved. To filter a page at other times in your application see [`refilter`](#dataset-actions).
+We fetch records using an immutable style, but we often require
+filtering by mutable records in our dataset. To enable filtering, pass
+a filter `callback` to `ember-impagination` as you would to
+`Array.prototype.filter()`. The filters are applied as soon as a page
+is resolved. To filter a page at other times in your application see
+[`refilter`](#dataset-actions).
 
 ```handlebars
 {{#impagination-dataset fetch=(action "fetch") filter=(action "filterCallback")}}
@@ -168,10 +219,15 @@ There are a number of public `impagination` functions which we provide as action
 | reset         | `offset`       |     0           | Destroys  all pages and fetches records at starting at `offset`
 | setReadOffset | `offset`       |   _none_        | Sets the readOffset and fetches records resuming at `offset`
 
-These functions can be called from the route/controller or from child components in the handlebars templates. In the examples below, we `reset` the dataset upon search queries through the {{search-pane}} component using both options.
+These functions can be called from the route/controller or from child
+components in the handlebars templates. In the examples below, we
+`reset` the dataset upon search queries through the {{search-pane}}
+component using both options.
 
 #### resetting from the parent route
-In order to call dataset actions from the route, we will have to observe the latest dataset and dataset-actions with the `on-observe` parameter.
+In order to call dataset actions from the route, we will have to
+observe the latest dataset and dataset-actions with the `on-observe`
+parameter.
 
 ```handlebars
 {{#search-pane search=(action "search")}}
@@ -197,16 +253,17 @@ actions: {
   search(query) {
     this.set('searchParams', query);
     this._resetDataset()
-  }
+  },
   fetch(pageOffset, pageSize, stats) {
     params = this.get('params)
     return this.store.query('records', params);
-  },
+  }
 }
 ```
 
 #### resetting from child components
-Here we do not need to utilize `impagination-dataset`'s `on-observe` parameter. The `reset` action is simply called by a child component.
+Here we do not need to utilize `impagination-dataset`'s `on-observe`
+parameter. The `reset` action is simply called by a child component.
 
 ```handlebars
 {{#impagination-dataset fetch=(action "fetch") as |dataset|}}
@@ -220,7 +277,12 @@ Here we do not need to utilize `impagination-dataset`'s `on-observe` parameter. 
 
 
 ### Create your own Dataset
-If `{{impagination-dataset}}` is not an ideal component for your unique `Impagination` needs, you can get into the nitty gritty, and use `Impagination` directly. If you find yourself creating your own `Dataset`, let us know how you are using `Dataset` and `Impagination`. It may be a reason for improvements or another ember addon.
+If `{{impagination-dataset}}` is not an ideal component for your
+unique `Impagination` needs, you can get into the nitty gritty, and
+use `Impagination` directly. If you find yourself creating your own
+`Dataset`, let us know how you are using `Dataset` and
+`Impagination`. It may be a reason for improvements or another ember
+addon.
 
 ```js
 import Dataset from 'impagination/dataset';
@@ -231,7 +293,8 @@ let dataset = new Dataset({
     return new Ember.RSVP.Promise((resolve)=> {
       let data = // Array
       resolve(data);
-    });
+    },
+
     return this.store.query('record', params).then((data) => {
       let meta = result.get('meta');
       stats.totalPages = meta.totalPages;


### PR DESCRIPTION
There were a couple code examples that had incorrect syntax. Also updated the line length in the readme to break out our ruler setting in emacs. 