### PR TITLE
Fix syntax errors in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ In order to call dataset actions from the route, we will have to observe the lat
 
 ``` javascript
 _resetDataset() {
-  let reset = this.get('actions.reset);
+  let reset = this.get('actions.reset');
   reset.call(this.get('dataset'));
-}
+},
 
 actions: {
   observeDataset: function(dataset, actions) { // dataset and actions are passed-up
@@ -196,12 +196,12 @@ actions: {
   },
   search(query) {
     this.set('searchParams', query);
-    this._resetDataset()
-  }
-  fetch(pageOffset, pageSize, stats) {
-    params = this.get('params)
-    return this.store.query('records', params);
+    this._resetDataset();
   },
+  fetch(pageOffset, pageSize, stats) {
+    params = this.get('params);
+    return this.store.query('records', params);
+  }
 }
 ```
 


### PR DESCRIPTION
Fixes some syntactical errors in one of the examples in the README.