### PR TITLE
Use the Travis Build Image From Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ember-Impagination
 [![npm version](https://badge.fury.io/js/ember-impagination.svg)](https://badge.fury.io/js/ember-impagination)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-impagination.svg)](http://emberobserver.com/addons/ember-impagination)
-[![Build Status](https://travis-ci.org/thefrontside/ember-impagination.svg)](https://travis-ci.org/thefrontside/ember-impagination)
+[![Build Status](https://travis-ci.org/thefrontside/ember-impagination.svg?branch=master)](https://travis-ci.org/thefrontside/ember-impagination)
 
 *Ember-Impagination* is an Ember binding for
 [Impagination](https://github.com/flexyford/impagination), a front-end


### PR DESCRIPTION
By default, the travis build SVG indicates that it's failing if *any* of the builds are not working. In a deeply ironic move, @greenkeeperio-bot turned our global build red by submitting a breaking [pull request](https://github.com/thefrontside/ember-impagination/pull/58).

This makes the image on the README refer directly to the master branch.