### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-impagination",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Version bump to alpha.5

I published alpha.4 under the `--tag alpha`, and therefore couldn't publish with `--tag latest` until we bumped to `alpha.5`

Sorry for all the tiny commits.