### PR TITLE
Make the `on-init` hook fired every time a new dataset is computed.

### DIFF
--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -38,9 +38,13 @@ export default Ember.Component.extend({
 
     let readOffsetAttrFound = get(this, 'read-offset') >= 0;
     Ember.warn('Ember Impagination: `read-offset` attribute has been removed. Please use the `on-init` function instead.', !readOffsetAttrFound, {id: 'ember-impagination.attributes.read-offset'});
-
-    this.get('on-init')(this.get('model'));
+    this.notifyOnInit();
   },
+
+  notifyOnInit: Ember.observer('dataset', function() {
+    let model = this.get('model');
+    this.get('on-init')(model);
+  }),
 
   arrayActions: Ember.computed(function() {
     let context = this;

--- a/addon/components/impagination-dataset.js
+++ b/addon/components/impagination-dataset.js
@@ -38,10 +38,10 @@ export default Ember.Component.extend({
 
     let readOffsetAttrFound = get(this, 'read-offset') >= 0;
     Ember.warn('Ember Impagination: `read-offset` attribute has been removed. Please use the `on-init` function instead.', !readOffsetAttrFound, {id: 'ember-impagination.attributes.read-offset'});
-    this.notifyOnInit();
+    this.fireOnInit();
   },
 
-  notifyOnInit: Ember.observer('dataset', function() {
+  fireOnInit: Ember.observer('dataset', function() {
     let model = this.get('model');
     this.get('on-init')(model);
   }),

--- a/tests/integration/components/impagination-dataset-test.js
+++ b/tests/integration/components/impagination-dataset-test.js
@@ -22,9 +22,9 @@ describe('Integration | Component | ImpaginationDataset', function() {
       return this.server.request(pageOffset, pageSize, stats);
     };
 
-    init = (dataset) => {
+    init = sinon.spy((dataset) => {
       dataset.setReadOffset(0);
-    };
+    });
 
     observe = sinon.spy();
 
@@ -95,6 +95,17 @@ describe('Integration | Component | ImpaginationDataset', function() {
       let first = model.objectAt(0);
       expect(first.content).to.be.null;
     });
+
+    describe("when the dataset is recomputed", function() {
+      beforeEach(function() {
+        init.reset();
+        this.set('page-size', 100);
+      });
+      it("fires the on-init hook again", function() {
+        expect(init).to.have.been.called;
+      });
+    });
+
 
     describe("resolving fetches", function() {
       beforeEach(function(done) {

--- a/tests/integration/components/impagination-dataset-test.js
+++ b/tests/integration/components/impagination-dataset-test.js
@@ -98,11 +98,10 @@ describe('Integration | Component | ImpaginationDataset', function() {
 
     describe("when the dataset is recomputed", function() {
       beforeEach(function() {
-        init.reset();
         this.set('page-size', 100);
       });
       it("fires the on-init hook again", function() {
-        expect(init).to.have.been.called;
+        expect(init.calledTwice).to.equal(true);
       });
     });
 

--- a/tests/integration/components/impagination-dataset-test.js
+++ b/tests/integration/components/impagination-dataset-test.js
@@ -98,7 +98,7 @@ describe('Integration | Component | ImpaginationDataset', function() {
 
     describe("when the dataset is recomputed", function() {
       beforeEach(function() {
-        this.set('page-size', 100);
+        this.set('pageSize', 100);
       });
       it("fires the on-init hook again", function() {
         expect(init.calledTwice).to.equal(true);


### PR DESCRIPTION
The on-init hook is designed to allow initialization code to run whenever the underlying impagination dataset is created. The most standard use-case for this is to kick off an action that sets the initial read offset, thereby causing the first page to be fetched. This hook fires whenever the component is first initialized.

However, the dataset property of the impagination-dataset component depends on several values. Specifically ['page-size', 'load-horizon', 'unload-horizon', 'fetch', 'on-observe', 'filter'] and so if any of those values change, the dataset will be recomputed and you'll restart with a completely new dataset state that has no records loaded. In those cases, you'll want your initialization hook that fires actions to load data initial data into the dataset to fire.

This ensures that every time a new dataset is computed, the `on-init` action will fire so that initial reads can happen.

Resolves #152 