### PR TITLE
bump ember-cli-babel to ^6.6.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-babel": "^6.0.0"
+    "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
Removes deprecation warnings during builds